### PR TITLE
Disabling YAML parse errors,

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,11 +5,11 @@ PATH
       addressable (~> 2.3)
       github_api (~> 0.12)
       highline (~> 1.6)
-      json (~> 1.8)
+      json
       launchy (~> 2.4)
       nayutaya-msgpack-pure (~> 0.0, >= 0.0.2)
       tddium_client (~> 0.4)
-      thor (~> 0.19)
+      thor
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,11 +5,11 @@ PATH
       addressable (~> 2.3)
       github_api (~> 0.12)
       highline (~> 1.6)
-      json
+      json (~> 1.8)
       launchy (~> 2.4)
       nayutaya-msgpack-pure (~> 0.0, >= 0.0.2)
       tddium_client (~> 0.4)
-      thor
+      thor (~> 0.19)
 
 GEM
   remote: http://rubygems.org/
@@ -64,7 +64,7 @@ GEM
       multi_xml
     httpclient (2.4.0)
     json (1.8.2)
-    jwt (1.3.0)
+    jwt (1.4.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     mimic (0.4.3)
@@ -117,11 +117,11 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    tddium_client (0.4.3)
+    tddium_client (0.5.0)
       httpclient (>= 2.2.5)
       json
     thor (0.19.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tilt (1.4.1)
 
 PLATFORMS

--- a/lib/solano/cli/commands/spec.rb
+++ b/lib/solano/cli/commands/spec.rb
@@ -303,7 +303,7 @@ module Solano
     end
 
     def read_and_encode_config_file
-      config, raw_config = @repo_config.read_config(true)
+      config, raw_config = @repo_config.read_config(false)
       encoded = Base64.encode64(raw_config)
       return encoded
     end

--- a/solano.gemspec
+++ b/solano.gemspec
@@ -30,9 +30,9 @@ EOF
   s.files         = `git ls-files lib bin`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_runtime_dependency("thor", "~> 0.19")
+  s.add_runtime_dependency("thor")
   s.add_runtime_dependency("highline", "~> 1.6")
-  s.add_runtime_dependency("json", "~> 1.8")
+  s.add_runtime_dependency("json")
   s.add_runtime_dependency("launchy", "~> 2.4")
   s.add_runtime_dependency("addressable", "~> 2.3")
   s.add_runtime_dependency("github_api", "~> 0.12")

--- a/solano.gemspec
+++ b/solano.gemspec
@@ -30,9 +30,9 @@ EOF
   s.files         = `git ls-files lib bin`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_runtime_dependency("thor")
+  s.add_runtime_dependency("thor", "~> 0.19")
   s.add_runtime_dependency("highline", "~> 1.6")
-  s.add_runtime_dependency("json")
+  s.add_runtime_dependency("json", "~> 1.8")
   s.add_runtime_dependency("launchy", "~> 2.4")
   s.add_runtime_dependency("addressable", "~> 2.3")
   s.add_runtime_dependency("github_api", "~> 0.12")


### PR DESCRIPTION
tddium_site now catches and reports these errors

Removing the specification of gem versions was in order to get tddium_system to use solano gem version 1.26.6 on my sandbox. These changes can be reverted as soon as tddium_system is ready to upgrade to the latest gem.