### PR TITLE
Allow solano rerun command to designate particular build profiles.

### DIFF
--- a/lib/solano/cli/commands/rerun.rb
+++ b/lib/solano/cli/commands/rerun.rb
@@ -29,7 +29,7 @@ module Solano
         'failed', 'error', 'notstarted', 'started'].include?(t['status']) }
       tests = tests.map{ |t| t['test_name'] }
 
-      profile = options[:profile]
+      profile = options[:profile] || result['non_passed_profile_name']
 
       cmd = "solano run"
       cmd += " --max-parallelism=#{options[:max_parallelism]}" if options[:max_parallelism]

--- a/spec/cli/commands/rerun_spec.rb
+++ b/spec/cli/commands/rerun_spec.rb
@@ -14,13 +14,15 @@ describe Solano::SolanoCli do
                                 {'status'=>'error', 'test_name'=>'foo2.rb'},
                                 {'status'=>'notstarted', 'test_name'=>'foo3.rb'},
                                 {'status'=>'started', 'test_name'=>'foo4.rb'}]
-                    }
+                    },
+
+        'non_passed_profile_name' => 'first'
       }
     }
 
     it "should produce a command line from an old session's results" do
       solano_api.should_receive(:query_session_tests).with(session_id).and_return(query_session_tests_result)
-      Kernel.should_receive(:exec).with(/solano run foo.rb foo2.rb foo3.rb foo4.rb/)
+      Kernel.should_receive(:exec).with(/solano run --profile=first foo.rb foo2.rb foo3.rb foo4.rb/)
 
       subject.rerun(session_id)
     end
@@ -29,7 +31,7 @@ describe Solano::SolanoCli do
       solano_api.should_receive(:current_suite_id).exactly(3).times.and_return(123)
       solano_api.should_receive(:get_sessions).and_return([{"id" => 1234}])
       solano_api.should_receive(:query_session_tests).with(1234).and_return(query_session_tests_result)
-      Kernel.should_receive(:exec).with(/solano run foo.rb foo2.rb foo3.rb foo4.rb/)
+      Kernel.should_receive(:exec).with(/solano run --profile=first foo.rb foo2.rb foo3.rb foo4.rb/)
 
       subject.rerun
     end


### PR DESCRIPTION
Link for the issue: https://jira.slno.net/jira/browse/CICLI-80
Depends on: https://github.com/solanolabs/tddium_site/pull/1889