### PR TITLE
Standardize handling --org parameter for config command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 
 ## Version History
-- v1.30.4 - Add base commit to patch upload
+- v1.30.5 - Standardize specification of organization name to CLI commands.
+- v1.30.4 - Add base commit to patch upload.
 - v1.30.3 - Handle non-string values in solano.yml.
 - v1.30.2 - Add better messaging around patching and snapshots
 - v1.30.1 - Use absolute paths for git, hg; only create patch if no snapshot.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solano (1.30.4)
+    solano (1.30.5)
       addressable (~> 2.3)
       highline (~> 1.7.3)
       json (~> 1.8.3)

--- a/features/config_command.feature
+++ b/features/config_command.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2011, 2012 Solano Labs All Rights Reserved
+# Copyright (c) 2011-2016 Solano Labs All Rights Reserved
 
 @mimic
 Feature: Config command
@@ -42,7 +42,7 @@ Scenario: Display account config without disambiguating account
 Scenario: Display account config without disambiguating account
   Given the user belongs to two accounts
   And the user is logged in with a configured suite on branch "test/foobar"
-  When I run `solano config org:not_my_account`
+  When I run `solano config org --org not_my_account`
   Then the output should contain "You aren't a member of organization"
   And the exit status should be 1
 
@@ -53,7 +53,7 @@ Scenario: Display account config for the first account
     | scope     | name      | value     |
     | account   | foo       | bar       |
     | suite     | quz       | blehher   |
-  When I run `solano config org:some_account`
+  When I run `solano config org --org some_account`
   Then the output should contain "foo=bar"
   And the exit status should be 0
 
@@ -64,7 +64,7 @@ Scenario: Display account config for the second account
     | scope     | name      | value     |
     | account   | foo       | bar       |
     | suite     | quz       | blehher   |
-  When I run `solano config org:another_account`
+  When I run `solano config org --org another_account`
   Then the output should not contain "foo=bar"
   And the exit status should be 0
 
@@ -103,6 +103,15 @@ Scenario: Add repo config
   Then the exit status should be 0
   And the output should contain "repo"
   And the output should contain "third=fourth"
+
+Scenario: Add org config for the first account
+  Given the user belongs to two accounts
+  And the user is logged in with a configured suite on branch "test/foobar"
+  And setting "key" on the account will succeed
+  When I run `solano config:add org key value --org some_account`
+  Then the exit status should be 0
+  And the output should contain "org"
+  And the output should contain "key=value"
 
 Scenario: Fail to add key if the user isn't logged in
   When I run `solano config:add suite third fourth`

--- a/lib/solano/cli/api.rb
+++ b/lib/solano/cli/api.rb
@@ -42,7 +42,7 @@ module Solano
       unless accounts.length == 1
         msg = "You are a member of more than one organization.\n"
         msg << "Please specify the organization you want to operate on with "
-        msg << "'org:an_organization_name'.\n"
+        msg << "'--org NAME'.\n"
         accounts.each do |acct|
           msg << "  #{acct["account"]}\n"
         end
@@ -63,6 +63,13 @@ module Solano
     end
 
     def env_path(scope, key=nil)
+      account_id = nil
+      if @api_config.cli_options[:account] then
+        account_id = get_account_id(@api_config.cli_options[:account])
+      end
+      if account_id.nil? then
+        account_id = get_single_account_id
+      end
       path = ['']
 
       case scope
@@ -72,17 +79,11 @@ module Solano
       when "repo"
         path << 'repos'
         path << current_repo_id
-      when "account", "org"
+      when "org"
         path << 'accounts'
-        path << get_single_account_id
-      when /\Aaccount:/
-        path << 'accounts'
-        path << get_account_id(scope.sub(/\Aaccount:/, ''))
-      when /\Aorg:/
-        path << 'accounts'
-        path << get_account_id(scope.sub(/\Aorg:/, ''))
+        path << account_id
       else
-        raise "Unrecognized scope. Use 'suite', 'repo', 'org', or 'org:an_organization_name'."
+        raise "Unrecognized scope. Use 'suite', 'repo', 'org'."
       end
 
       path << 'env'

--- a/lib/solano/cli/commands/config.rb
+++ b/lib/solano/cli/commands/config.rb
@@ -2,14 +2,17 @@
 
 module Solano
   class SolanoCli < Thor
-    desc "config [suite | repo | org[:ACCOUNT]]", "Display config variables.
-    The scope argument can be 'suite', 'repo', 'org' (if you are a member of
-    one organization), or 'org:an_organization_name' (if you are a member of
-    multiple organizations). The default is 'suite'."
+    desc "config [suite | repo | org] [--org NAME]", "Display config variables.
+    The scope argument can be 'suite', 'repo', 'org'. The default is 'suite'."
+    method_option :account, :type => :string, :default => nil,
+      :aliases => %w(--org --organization)
     def config(scope="suite")
       params = {:repo => true}
       if scope == 'suite' then
         params[:suite] = true
+      end
+      if options[:account] then
+        params[:account] = options[:account]
       end
       solano_setup(params)
 
@@ -23,14 +26,17 @@ module Solano
       end
     end
 
-    desc "config:add [SCOPE] [KEY] [VALUE]", "Set KEY=VALUE at SCOPE.
-    The scope argument can be 'suite', 'repo', 'org' (if you are a member of
-    one organization), or 'org:an_organization_name' (if you are a member of
-    multiple organizations)."
+    desc "config:add [SCOPE] [KEY] [VALUE] [--org NAME]", "Set KEY=VALUE at SCOPE.
+    The scope argument can be 'suite', 'repo', 'org'."
+    method_option :account, :type => :string, :default => nil,
+      :aliases => %w(--org --organization)
     define_method "config:add" do |scope, key, value|
       params = {:repo => true}
       if scope == 'suite' then
         params[:suite] = true
+      end
+      if options[:account] then
+        params[:account] = options[:account]
       end
       solano_setup(params)
 
@@ -45,11 +51,16 @@ module Solano
       end
     end
 
-    desc "config:remove [SCOPE] [KEY]", "Remove config variable NAME from SCOPE."
+    desc "config:remove [SCOPE] [KEY] [--org NAME]", "Remove config variable NAME from SCOPE."
+    method_option :account, :type => :string, :default => nil,
+      :aliases => %w(--org --organization)
     define_method "config:remove" do |scope, key|
       params = {:repo => true}
       if scope == 'suite' then
         params[:suite] = true
+      end
+      if options[:account] then
+        params[:account] = options[:account]
       end
       solano_setup(params)
 

--- a/lib/solano/cli/config.rb
+++ b/lib/solano/cli/config.rb
@@ -75,7 +75,7 @@ module Solano
   class ApiConfig
     include SolanoConstant
 
-    attr_reader :config
+    attr_reader :config, :cli_options
 
     # BOTCH: should be a state object rather than entire CLI object
     def initialize(scm, tddium_client, host, cli_options)
@@ -185,7 +185,7 @@ module Solano
         write_scm_ignore		# BOTCH: no need to write every time
       end
     end
-    
+
     def write_scm_ignore
       path = @scm.ignore_path
       content = File.exists?(path) ? File.read(path) : ''

--- a/lib/solano/version.rb
+++ b/lib/solano/version.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2011-2016 Solano Labs All Rights Reserved
 
 module Solano
-  VERSION = "1.30.4"
+  VERSION = "1.30.5"
 end


### PR DESCRIPTION
JIRA Story - https://jira.slno.net/jira/browse/CICLI-94


Demo Examples:

```bash
[vagrant@solano solano] ./bin/solano
Commands:
...
  solano account [--org NAME]                          # View account information
  solano config [suite | repo | org] [--org NAME]      # Display config variables. The scope argument can be 'suite', 'repo', 'org'. The default is 'suite'.
  solano config:add [SCOPE] [KEY] [VALUE] [--org NAME] # Set KEY=VALUE at SCOPE. The scope argument can be 'suite', 'repo', 'org'.
  solano config:remove [SCOPE] [KEY] [--org NAME]      # Remove config variable NAME from SCOPE.

[vagrant@solano solano] ./bin/solano config repo
You are a member of more than one organization.
Please specify the organization you want to operate on with '--org NAME'.
  handle1
  admin1

[vagrant@solano solano] ./bin/solano config repo --org qwe
You aren't a member of organization 'qwe'.

[vagrant@solano solano] ./bin/solano config repo --org handle1
The following environment variables are set for this repo:

xx=12
yy=33

Use `solano config:add <scope> <key> <value>` to set a config key.
Use `solano config:remove <scope> <key>` to remove a key.

[vagrant@solano solano] ./bin/solano config repo --org admin1
The following environment variables are set for this repo:

hh=bb
qw=qw

Use `solano config:add <scope> <key> <value>` to set a config key.
Use `solano config:remove <scope> <key>` to remove a key.

[vagrant@solano solano] ./bin/solano config org --org admin1
The following environment variables are set for this org:

hh=bb

Use `solano config:add <scope> <key> <value>` to set a config key.
Use `solano config:remove <scope> <key>` to remove a key.

[vagrant@solano solano] ./bin/solano config org --org handle1
The following environment variables are set for this org:

xx=12
yy=33

Use `solano config:add <scope> <key> <value>` to set a config key.
Use `solano config:remove <scope> <key>` to remove a key.

[vagrant@solano solano] ./bin/solano config:add repo zz 44 --org handle1
Adding config zz=44 to repo
Added config zz=44 to repo

[vagrant@solano solano] ./bin/solano config repo --org handle1
The following environment variables are set for this repo:

xx=12
yy=33
zz=44

Use `solano config:add <scope> <key> <value>` to set a config key.
Use `solano config:remove <scope> <key>` to remove a key.

[vagrant@solano solano]
[vagrant@solano solano] ./bin/solano config org --org handle1
The following environment variables are set for this org:

xx=12
yy=33

Use `solano config:add <scope> <key> <value>` to set a config key.
Use `solano config:remove <scope> <key>` to remove a key.

```
